### PR TITLE
Fix `try*.c` check programs. C99 requires `int main()`.

### DIFF
--- a/tryflock.c
+++ b/tryflock.c
@@ -4,7 +4,7 @@
 #include <sys/file.h>
 #include <fcntl.h>
 
-main()
+int main()
 {
   flock(0,LOCK_EX | LOCK_UN | LOCK_NB);
 }

--- a/trysgact.c
+++ b/trysgact.c
@@ -2,7 +2,7 @@
 
 #include <signal.h>
 
-main()
+int main()
 {
   struct sigaction sa;
   sa.sa_handler = 0;

--- a/trysgprm.c
+++ b/trysgprm.c
@@ -2,7 +2,7 @@
 
 #include <signal.h>
 
-main()
+int main()
 {
   sigset_t ss;
  

--- a/trywaitp.c
+++ b/trywaitp.c
@@ -3,7 +3,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-main()
+int main()
 {
   waitpid(0,0,0);
 }


### PR DESCRIPTION
```
type specifier missing, defaults to 'int';
ISO C99 and later do not support implicit int [-Wimplicit-int] "main"
```